### PR TITLE
Update Readme to Make Linter Happy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sequoia Flight Software
 
 See https://wiki.stanfordssi.org/Satellite_Software for information on the team and documentation.
-### Practice PR Names
+## Practice PR Names
 - Langston
 - Arnav

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sequoia Flight Software
 
-See https://wiki.stanfordssi.org/Satellite_Software for information on the team and documentation.
+See <https://wiki.stanfordssi.org/Satellite_Software> for information on the team and documentation.
 ## Practice PR Names
 - Langston
 - Arnav


### PR DESCRIPTION
Linter was throwing error because of mismatched heading depth.