### PR TITLE
Update Linter Config to Ignore Markdown Files

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -50,3 +50,4 @@ jobs:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: master
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VALIDATE_MARKDOWN: false


### PR DESCRIPTION
# Summary

The markdown is currently validating Markdown files, and I believe fixing various errors in Markdown is not a good use of time. We could also create a markdown validator with a more limited set of rules, but for now, I just want to disable Markdown formatting entirely. 

## Test Plan

Not sure how we can test this besides just merging since it deals with the Github Tooling, but it's based on the docentation here: https://github.com/github/super-linte. 

## Related Issues
N/A 
