### PR TITLE
Update linter.yml to use only pylint

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -44,8 +44,8 @@ jobs:
       ################################
       # Run Linter against code base #
       ################################
-      - name: Lint Code Base
-        uses: github/super-linter@v3
+      - name: GitHub Action for pylint
+        uses: cclauss/GitHub-Action-for-pylint@0.7.0
         env:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: master


### PR DESCRIPTION
# Summary

We are using GH superlinter, this is distracting and opens unnecessary arguments about syntax. We should move to using one linter.
