### PR TITLE
Update Linter to only include PyLint

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -51,5 +51,4 @@ jobs:
           DEFAULT_BRANCH: master
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FILTER_REGEX_EXCLUDE: flight_computer/lib/.*
-          VALIDATE_MARKDOWN: false
-          VALIDATE_PYTHON_ISORT: false
+          VALIDATE_PYTHON_PYLINT: true


### PR DESCRIPTION
# Summary

We were linting with three linters before, and it was causing too much overhead for the benefit we were receiving. This PR only uses PyLint, and we can reenable other linters as needed. 